### PR TITLE
Add WinUI Toolkit Bug Template to .github docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/WinUI_Toolkit_Issue.md
+++ b/.github/ISSUE_TEMPLATE/WinUI_Toolkit_Issue.md
@@ -1,0 +1,28 @@
+---
+name: WinUI Design Toolkit Bug report
+about: File a WinUI Design Toolkit bug report
+title: 'WinUI Design Toolkit Bug: [descriptive bug title here]'
+labels: Toolkit, WinUI2.6
+assignees: ''
+
+---
+
+## WinUI Toolkit Bug Report
+
+---
+
+Please use this template to report a bug in the WinUI Design Toolkit.
+<br/>
+<br/>
+
+**Name of component or part of Toolkit:**
+<!-- Please indicate which control you are reporting  -->
+
+**Describe the bug:**
+<!-- Please enter a short, clear description of the bug -->
+
+**Version Info:**
+<!-- Please indicate which version of the toolkit you are using -->
+
+**Additional context:**
+<!-- Enter any other applicable info here -->


### PR DESCRIPTION
Adding the WinUI toolkit but template to the .github docs folder. Users will complete this template to file a bug.

## Description
Adding a .md file for the WinUI Toolkit Bug Template

## Motivation and Context
Necessary for community to file bugs in the toolkit.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
N/A